### PR TITLE
Updates to prepare for package registration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false
@@ -11,3 +12,5 @@ notifications:
 #script:
 #  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("RData"); Pkg.test("RData"; coverage=true)'
+after_success:
+  - julia -e 'cd(Pkg.dir("RData")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # RData
+
+[![Build Status](https://travis-ci.org/JuliaStats/RData.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/RData.jl)
+[![Coverage Status](https://coveralls.io/repos/github/JuliaStats/RData.jl/badge.svg)](https://coveralls.io/github/JuliaStats/RData.jl)
+
+Read R data files (.rda, .RData) to native Julia objects.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4-
+julia 0.4
 DataFrames
 DataArrays
 GZip


### PR DESCRIPTION
This bumps the Julia requirement to 0.4 release; runs Travis on 0.4, 0.5, and nightly; and adds badges to the readme. Someone will need to enable Travis for this repo.