### PR TITLE
Don't export read_rda, qualify all calls to read_rda in tests

### DIFF
--- a/src/RData.jl
+++ b/src/RData.jl
@@ -4,7 +4,7 @@ using Compat, DataFrames, GZip
 import DataArrays: data
 import DataFrames: identifier
 import Base: convert, get, haskey, keys, values, length, show
-import Compat: unsafe_string
+import Compat: UTF8String, unsafe_string
 
 export
     # read_rda,

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -4,6 +4,7 @@ using Compat, DataFrames, GZip
 import DataArrays: data
 import DataFrames: identifier
 import Base: convert, get, haskey, keys, values, length, show
+import Compat: unsafe_string
 
 export
     # read_rda,

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -1,7 +1,14 @@
 module RData
 
-using Compat, DataFrames, DataFrames.identifier, GZip
-import DataArrays.data, Base.convert, Base.get, Base.haskey, Base.keys, Base.values, Base.length, Base.show
+using Compat, DataFrames, GZip
+import DataArrays: data
+import DataFrames: identifier
+import Base: convert, get, haskey, keys, values, length, show
+
+export
+    # read_rda,
+    sexp2julia,
+    DictoVec
 
 include("config.jl")
 include("sxtypes.jl")
@@ -64,6 +71,5 @@ read_rda(io::IO; kwoptions...) = read_rda(io, kwoptions)
 
 read_rda(fnm::AbstractString; kwoptions...) = gzopen(fnm) do io read_rda(io, kwoptions) end
 
-export read_rda, sexp2julia, DictoVec
 
 end # module

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -3,7 +3,6 @@ module RData
 using Compat, DataFrames, GZip
 import DataArrays: data
 import DataFrames: identifier
-import Base: convert, get, haskey, keys, values, length, show
 import Compat: UTF8String, unsafe_string
 
 export

--- a/src/config.jl
+++ b/src/config.jl
@@ -12,7 +12,7 @@ end
 const R_NA_INT32 = typemin(Int32)
 const R_NA_STRING = "NA"
 
-const LONG_VECTOR_SUPPORT = (WORD_SIZE > 32) # disable long vectors support on 32-bit machines
+const LONG_VECTOR_SUPPORT = (Sys.WORD_SIZE > 32) # disable long vectors support on 32-bit machines
 
 if LONG_VECTOR_SUPPORT
     typealias RVecLength Int64

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -15,11 +15,11 @@ end
 ##
 ##############################################################################
 
-namask(rl::RLogicalVector) = bitpack(rl.data .== R_NA_INT32)
-namask(ri::RIntegerVector) = bitpack(ri.data .== R_NA_INT32)
-namask(rn::RNumericVector) = bitpack(Bool[rn.data[i] === R_NA_FLOAT64 for i in 1:length(rn.data)])
-namask(rc::RComplexVector) = bitpack(Bool[rc.data[i].re === R_NA_FLOAT64 ||
-                                          rc.data[i].im === R_NA_FLOAT64 for i in 1:length(rc.data)])
+namask(rl::RLogicalVector) = BitArray(rl.data .== R_NA_INT32)
+namask(ri::RIntegerVector) = BitArray(ri.data .== R_NA_INT32)
+namask(rn::RNumericVector) = BitArray(Bool[rn.data[i] === R_NA_FLOAT64 for i in 1:length(rn.data)])
+namask(rc::RComplexVector) = BitArray(Bool[rc.data[i].re === R_NA_FLOAT64 ||
+                                           rc.data[i].im === R_NA_FLOAT64 for i in 1:length(rc.data)])
 namask(rv::RNullableVector) = rv.na
 
 DataArrays.data(rv::RVEC) = DataArray(rv.data, namask(rv))

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -20,5 +20,5 @@ readuint8(io::XDRIO, n::RVecLength) = readbytes(io.sub, n)
 
 function readnchars(io::XDRIO, n::Int32)  # a single character string
     readbytes!(io.sub, io.buf, n)
-    convert(RString, bytestring(pointer(io.buf), n) )
+    convert(RString, unsafe_string(pointer(io.buf), n) )
 end

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -222,17 +222,18 @@ end
 
 function readbytecodeconsts( bctx::BytecodeContext )
     nconsts = readint32(bctx.ctx.io)
-    RList( [ begin
+    v = Vector{RSEXPREC}(nconsts)
+    @inbounds for i = 1:nconsts
         bctype = readint32(bctx.ctx.io)
-        if bctype == BCODESXP
+        v[i] = if bctype == BCODESXP
             readbytecodecontents(bctx)
-        elseif bctype ∈ [ BCREPDEF, BCREPDEF, LANGSXP, LISTSXP, ATTRLANGSXP, ATTRLISTSXP ]
+        elseif bctype ∈ [BCREPDEF, BCREPDEF, LANGSXP, LISTSXP, ATTRLANGSXP, ATTRLISTSXP]
             readbytecodelang(bctx, bctype)
         else
             readitem(bctx.ctx)
         end
-        end
-        for i in 1:nconsts ] )
+    end
+    return RList(v)
 end
 
 function readbytecodecontents( bctx::BytecodeContext )

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -244,7 +244,7 @@ end
 function readbytecode( ctx::RDAContext, fl::RDATag )
     @assert fl == BCODESXP
     res = readbytecodecontents( BytecodeContext( ctx, readint32( ctx.io ) ) )
-    res.attrs = readattrs( ctx, fl )
+    res.attr = readattrs( ctx, fl )
     return res
 end
 

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -188,7 +188,7 @@ type BytecodeContext # bytecode reading context
     ctx::RDAContext  # parent RDA context
     ref_tab::Vector  # table of bytecode references
 
-    BytecodeContext( ctx::RDAContext, nrefs::Int32 ) = new( ctx, Array( Any, int(nrefs) ) )
+    BytecodeContext( ctx::RDAContext, nrefs::Int32 ) = new( ctx, Array( Any, Int(nrefs) ) )
 end
 
 function readbytecodelang(bctx::BytecodeContext, bctype::Int32)

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -14,7 +14,7 @@ module TestRDA
         # df['chr'] = c('ab', 'c')
         # df['factor'] = factor(df$chr)
         # df['cplx'] = complex( real=c(1.1,0.0), imaginary=c(0.5,1.0) )
-        # #utf=c('Ж', '∰')) R handles it, read_rda doesn't.
+        # #utf=c('Ж', '∰')) R handles it, RData.read_rda doesn't.
         # save(df, file='types.rda')
         # save(df, file='types_ascii.rda', ascii=TRUE)
 
@@ -57,39 +57,39 @@ module TestRDA
     testdir = dirname(@__FILE__)
 
     df = DataFrame(num = [1.1, 2.2])
-    @test isequal(sexp2julia(read_rda("$testdir/data/minimal.rda",convert=false)["df"]), df)
-    @test isequal(read_rda("$testdir/data/minimal.rda",convert=true)["df"], df)
-    @test isequal(open(read_rda,"$testdir/data/minimal_ascii.rda")["df"], df)
+    @test isequal(sexp2julia(RData.read_rda("$testdir/data/minimal.rda",convert=false)["df"]), df)
+    @test isequal(RData.read_rda("$testdir/data/minimal.rda",convert=true)["df"], df)
+    @test isequal(open(RData.read_rda,"$testdir/data/minimal_ascii.rda")["df"], df)
 
     df[:int] = Int32[1, 2]
     df[:logi] = [true, false]
     df[:chr] = ["ab", "c"]
     df[:factor] = pool(df[:chr])
     df[:cplx] = Complex128[1.1+0.5im, 1.0im]
-    @test isequal(sexp2julia(read_rda("$testdir/data/types.rda",convert=false)["df"]), df)
-    @test isequal(sexp2julia(read_rda("$testdir/data/types_ascii.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(RData.read_rda("$testdir/data/types.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(RData.read_rda("$testdir/data/types_ascii.rda",convert=false)["df"]), df)
 
     df[2, :] = NA
     append!(df, df[2, :])
     df[3, :num] = NaN
     df[:, :cplx] = @data [NA, @compat(Complex128(1,NaN)), NaN]
-    @test isequal(sexp2julia(read_rda("$testdir/data/NAs.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(RData.read_rda("$testdir/data/NAs.rda",convert=false)["df"]), df)
     # ASCII format saves NaN as NA
     df[3, :num] = NA
     df[:, :cplx] = @data [NA, NA, NA]
-    @test isequal(sexp2julia(read_rda("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(RData.read_rda("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
 
-    rda_names = names(sexp2julia(read_rda("$testdir/data/names.rda",convert=false)["df"]))
+    rda_names = names(sexp2julia(RData.read_rda("$testdir/data/names.rda",convert=false)["df"]))
     expected_names = [:_end, :x!, :x1, :_B_C_, :x, :x_1]
     @test rda_names == expected_names
-    rda_names = names(sexp2julia(read_rda("$testdir/data/names_ascii.rda",convert=false)["df"]))
+    rda_names = names(sexp2julia(RData.read_rda("$testdir/data/names_ascii.rda",convert=false)["df"]))
     @test rda_names == [:_end, :x!, :x1, :_B_C_, :x, :x_1]
 
-    rda_envs = read_rda("$testdir/data/envs.rda",convert=false)
+    rda_envs = RData.read_rda("$testdir/data/envs.rda",convert=false)
 
-    rda_pairlists = read_rda("$testdir/data/pairlists.rda",convert=false)
+    rda_pairlists = RData.read_rda("$testdir/data/pairlists.rda",convert=false)
 
-    rda_closures = read_rda("$testdir/data/closures.rda",convert=false)
+    rda_closures = RData.read_rda("$testdir/data/closures.rda",convert=false)
 
-    rda_cmpfuns = read_rda("$testdir/data/cmpfun.rda",convert=false)
+    rda_cmpfuns = RData.read_rda("$testdir/data/cmpfun.rda",convert=false)
 end


### PR DESCRIPTION
This should fix the currently failing tests. As it stands, DataFrames exports `read_rda`, so calling it here is ambiguous. Thus I've removed it from the export list and qualified all calls to `read_rda` in the tests with `RData.`. Once the RDA stuff is moved out of DataFrames, we should be able to undo this here without consequence.