### PR TITLE
Fix float NA issues on Win32

### DIFF
--- a/src/DictoVec.jl
+++ b/src/DictoVec.jl
@@ -1,10 +1,10 @@
-function name2index( names::Vector{RString} )
+function name2index(names::Vector{RString})
     n2i = Dict{RString,Int64}()
     i2n = Dict{Int64,RString}()
-    for i in eachindex(names)
-        if names[i] != ""
-            n2i[names[i]] = i
-            i2n[i] = names[i]
+    @inbounds for (i,k) in enumerate(names)
+        if k != ""
+            n2i[k] = i
+            i2n[i] = k
         end
     end
     n2i, i2n
@@ -20,13 +20,9 @@ immutable DictoVec{T}
     name2index::Dict{RString, Int}
     index2name::Dict{Int, RString}
 
-    function Base.call{T}(::Type{DictoVec}, data::T, names::Vector{RString})
+    @compat function (::Type{DictoVec}){T}(data::T, names::Vector{RString} = Vector{RString}())
         n2i, i2n = name2index(names)
         new{T}(data, n2i, i2n)
-    end
-
-    function Base.call{T}(::Type{DictoVec}, data::T)
-        new{T}(data, Dict{RString,Int}(), Dict{Int,RString}())
     end
 end
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,14 +1,20 @@
 ##############################################################################
 ##
 ## Constants used as NA patterns in R.
+## 0x000007a2 == UInt32(1954) is a non-standard addition to NaN bit pattern
+## to discriminate NA from NaN.
 ## (I assume 1954 is the year of Ross's birth or something like that.)
+## Note that float NA are defined as UInt64 to workaround the win32 ABI
+# issue (see JuliaStats/RData.jl#5 and JuliaLang/julia#17195).
 ##
 ##############################################################################
+
 if ENDIAN_BOM == 0x01020304
-    const R_NA_FLOAT64 = reinterpret(Float64, [0x7ff00000, @compat(UInt32(1954))])[1]
+    const R_NA_FLOAT64 = 0x000007a27ff00000
 else
-    const R_NA_FLOAT64 = reinterpret(Float64, [@compat(UInt32(1954)), 0x7ff00000])[1]
+    const R_NA_FLOAT64 = 0x7ff00000000007a2
 end
+
 const R_NA_INT32 = typemin(Int32)
 const R_NA_STRING = "NA"
 

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -17,9 +17,10 @@ end
 
 namask(rl::RLogicalVector) = BitArray(rl.data .== R_NA_INT32)
 namask(ri::RIntegerVector) = BitArray(ri.data .== R_NA_INT32)
-namask(rn::RNumericVector) = BitArray(Bool[rn.data[i] === R_NA_FLOAT64 for i in 1:length(rn.data)])
-namask(rc::RComplexVector) = BitArray(Bool[rc.data[i].re === R_NA_FLOAT64 ||
-                                           rc.data[i].im === R_NA_FLOAT64 for i in 1:length(rc.data)])
+namask(rn::RNumericVector) = BitArray(reinterpret(UInt64, rn.data) .== R_NA_FLOAT64)
+# if re or im is NA, the whole complex number is NA
+# FIXME avoid temporary Vector{Bool}
+namask(rc::RComplexVector) = BitArray([v.re == R_NA_FLOAT64 || v.im == R_NA_FLOAT64 for v in reinterpret(Complex{UInt64}, rc.data)])
 namask(rv::RNullableVector) = rv.na
 
 DataArrays.data(rv::RVEC) = DataArray(rv.data, namask(rv))

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -13,8 +13,10 @@ readfloat64(io::XDRIO) = ntoh(read(io.sub, Float64))
 readintorNA(io::XDRIO) = readint32(io)
 readintorNA(io::XDRIO, n::RVecLength) = map!(ntoh, read(io.sub, Int32, n))
 
-readfloatorNA(io::XDRIO) = readfloat64(io)
-readfloatorNA(io::XDRIO, n::RVecLength) = map!(ntoh, read(io.sub, Float64, n))
+# this method have Win32 ABI issues, see JuliaStats/RData.jl#5
+# R's NA is silently converted to NaN when the value is loaded in the register(?)
+#readfloatorNA(io::XDRIO) = readfloat64(io)
+readfloatorNA(io::XDRIO, n::RVecLength) = reinterpret(Float64, map!(ntoh, read(io.sub, UInt64, n)))
 
 readuint8(io::XDRIO, n::RVecLength) = readbytes(io.sub, n)
 

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -38,8 +38,7 @@ end
 function readcomplex(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == CPLXSXP
     n = readlength(ctx.io)
-    data = readfloatorNA(ctx.io, 2n)
-    RComplexVector(Complex128[@compat(Complex128(data[i],data[i+1])) for i in 2(1:n)-1],
+    RComplexVector(reinterpret(Complex128, readfloatorNA(ctx.io, 2n)),
                    readattrs(ctx, fl))
 end
 

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -73,12 +73,7 @@ typealias RDATag UInt32
 isobj(fl::RDATag) = (fl & 0x00000100) != 0
 hasattr(fl::RDATag) = (fl & 0x00000200) != 0
 hastag(fl::RDATag) = (fl & 0x00000400) != 0
-
-if VERSION < v"0.4-"
-    sxtype = uint8
-else
-    sxtype(fl::RDATag) = fl % UInt8
-end
+sxtype(fl::RDATag) = fl % UInt8
 
 ##############################################################################
 ##


### PR DESCRIPTION
Fixes tests failing on Win32 due to JuliaLang/julia#17195.
Largely based on JuliaStats/DataFrames.jl#1006.
Should be merged to the master after #2.