### PR TITLE
Replace read_rda() by FileIO integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,27 @@
 [![Build Status](https://travis-ci.org/JuliaStats/RData.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/RData.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/JuliaStats/RData.jl?svg=true&branch=master)](https://ci.appveyor.com/project/alyst/rdata-jl/branch/master)
 
-Read R data files (.rda, .RData) to native Julia objects.
+Read R data files (.rda, .RData) and optionally convert the contents into Julia equivalents.
+
+Can read any R data archive, although not all R types could be converted into Julia.
+
+Usage
+-----
+
+To read R objects from "example.rda" file:
+```julia
+using RData
+
+objs = load("path_to/example.rda")
+```
+
+The result is a dictionary of all R objects that are stored in "example.rda".
+
+If `convert=true` keyword option is specified, `load()` will try to automatically
+convert R objects into Julia equivalents:
+ * data frames into `DataFrames.DataFrame`
+ * named vectors into `DictoVec` objects that allow indexing both by element indices and by names
+ * ...
+
+If the conversion to Julia type is not supported (e.g. R closure or language expression),
+the internal RData representation of the object will be provided.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.4
 DataFrames
 DataArrays
+FileIO
 GZip
 Compat

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -4,10 +4,12 @@ using Compat, DataFrames, GZip, FileIO
 import DataArrays: data
 import DataFrames: identifier
 import Compat: UTF8String, unsafe_string
+import FileIO: load
 
 export
     sexp2julia,
-    DictoVec
+    DictoVec,
+    load # export FileIO.load()
 
 include("config.jl")
 include("sxtypes.jl")

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -3,6 +3,7 @@ module TestRDA
     using DataFrames
     using RData
     using Compat
+    using FileIO
 
     # R code generating test .rdas
         # df = data.frame(num=c(1.1, 2.2))
@@ -14,7 +15,7 @@ module TestRDA
         # df['chr'] = c('ab', 'c')
         # df['factor'] = factor(df$chr)
         # df['cplx'] = complex( real=c(1.1,0.0), imaginary=c(0.5,1.0) )
-        # #utf=c('Ж', '∰')) R handles it, RData.read_rda doesn't.
+        # #utf=c('Ж', '∰')) R handles it, RData doesn't.
         # save(df, file='types.rda')
         # save(df, file='types_ascii.rda', ascii=TRUE)
 
@@ -57,39 +58,39 @@ module TestRDA
     testdir = dirname(@__FILE__)
 
     df = DataFrame(num = [1.1, 2.2])
-    @test isequal(sexp2julia(RData.read_rda("$testdir/data/minimal.rda",convert=false)["df"]), df)
-    @test isequal(RData.read_rda("$testdir/data/minimal.rda",convert=true)["df"], df)
-    @test isequal(open(RData.read_rda,"$testdir/data/minimal_ascii.rda")["df"], df)
+    @test isequal(sexp2julia(load("$testdir/data/minimal.rda",convert=false)["df"]), df)
+    @test isequal(load("$testdir/data/minimal.rda",convert=true)["df"], df)
+    @test isequal(load("$testdir/data/minimal_ascii.rda")["df"], df)
 
     df[:int] = Int32[1, 2]
     df[:logi] = [true, false]
     df[:chr] = ["ab", "c"]
     df[:factor] = pool(df[:chr])
     df[:cplx] = Complex128[1.1+0.5im, 1.0im]
-    @test isequal(sexp2julia(RData.read_rda("$testdir/data/types.rda",convert=false)["df"]), df)
-    @test isequal(sexp2julia(RData.read_rda("$testdir/data/types_ascii.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(load("$testdir/data/types.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(load("$testdir/data/types_ascii.rda",convert=false)["df"]), df)
 
     df[2, :] = NA
     append!(df, df[2, :])
     df[3, :num] = NaN
     df[:, :cplx] = @data [NA, @compat(Complex128(1,NaN)), NaN]
-    @test isequal(sexp2julia(RData.read_rda("$testdir/data/NAs.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(load("$testdir/data/NAs.rda",convert=false)["df"]), df)
     # ASCII format saves NaN as NA
     df[3, :num] = NA
     df[:, :cplx] = @data [NA, NA, NA]
-    @test isequal(sexp2julia(RData.read_rda("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
+    @test isequal(sexp2julia(load("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
 
-    rda_names = names(sexp2julia(RData.read_rda("$testdir/data/names.rda",convert=false)["df"]))
+    rda_names = names(sexp2julia(load("$testdir/data/names.rda",convert=false)["df"]))
     expected_names = [:_end, :x!, :x1, :_B_C_, :x, :x_1]
     @test rda_names == expected_names
-    rda_names = names(sexp2julia(RData.read_rda("$testdir/data/names_ascii.rda",convert=false)["df"]))
+    rda_names = names(sexp2julia(load("$testdir/data/names_ascii.rda",convert=false)["df"]))
     @test rda_names == [:_end, :x!, :x1, :_B_C_, :x, :x_1]
 
-    rda_envs = RData.read_rda("$testdir/data/envs.rda",convert=false)
+    rda_envs = load("$testdir/data/envs.rda",convert=false)
 
-    rda_pairlists = RData.read_rda("$testdir/data/pairlists.rda",convert=false)
+    rda_pairlists = load("$testdir/data/pairlists.rda",convert=false)
 
-    rda_closures = RData.read_rda("$testdir/data/closures.rda",convert=false)
+    rda_closures = load("$testdir/data/closures.rda",convert=false)
 
-    rda_cmpfuns = RData.read_rda("$testdir/data/cmpfun.rda",convert=false)
+    rda_cmpfuns = load("$testdir/data/cmpfun.rda",convert=false)
 end

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -3,7 +3,6 @@ module TestRDA
     using DataFrames
     using RData
     using Compat
-    using FileIO
 
     # R code generating test .rdas
         # df = data.frame(num=c(1.1, 2.2))


### PR DESCRIPTION
`read_rda()` calls is replaced by the generic FileIO `load()` mechanism as proposed in #2.

 - [ ] Do we need any other rdata loading methods?
 - [x] The tests pass, but I'm not sure whether `detect_rdata()` is actually called. _fixed_
 - [x] Should the user explicitly type `using FileIO` or `RData` should handle this (how?)? _FileIO.load is exported_