### PR TITLE
Remove FileIO add_format()

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 DataFrames 0.7
 DataArrays 0.3
-FileIO 0.1
+FileIO 0.1.2
 GZip 0.2
 Compat 0.8

--- a/src/DictoVec.jl
+++ b/src/DictoVec.jl
@@ -57,17 +57,17 @@ function Base.getindex(dict::DictoVec, key)
     end
 end
 
-Base.get(dict::DictoVec, index::Int, default) = get( dict.data, index, default )
+Base.get(dict::DictoVec, index::Int, default) = get(dict.data, index, default)
 
 function Base.get(dict::DictoVec, key, default)
-    ix = get( dict.name2index, key, 0 )
+    ix = get(dict.name2index, key, 0)
     return ix > 0 ? dict.data[ix] : default
 end
 
 Base.get(f::Function, dict::DictoVec, index::Int) = get(f, dict.data, index)
 
 function Base.get(f::Function, dict::DictoVec, key)
-    ix = get( dict.name2index, key, 0 )
+    ix = get(dict.name2index, key, 0)
     return ix > 0 ? dict.data[ix] : f()
 end
 
@@ -90,7 +90,7 @@ function Base.show(io::IO, dict::DictoVec)
         for i in eachindex(dict.data)
             first || print(io, ',')
             first = false
-            k = get( dict.index2name, i, "" )
+            k = get(dict.index2name, i, "")
             if k != ""
                 show(io, k)
                 print(io, "=>")

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -42,15 +42,6 @@ include("readers.jl")
 ##
 ##############################################################################
 
-# test for RD?2 magic sequence at the beginning of R data input stream
-function detect_rdata(io)
-    read(io, UInt8) == UInt8('R') &&
-    read(io, UInt8) == UInt8('D') &&
-    (fmt = read(io, UInt8); fmt == UInt8('A') || fmt == UInt8('B') || fmt == UInt8('X')) &&
-    read(io, UInt8) == UInt8('2') &&
-    read(io, UInt8) == 0x0A
-end
-
 function load(f::File{format"RData"}; kwoptions...)
     gzopen(filename(f)) do s
         load(Stream(f, s), kwoptions)
@@ -59,7 +50,7 @@ end
 
 function load(s::Stream{format"RData"}, kwoptions::Vector{Any})
     io = stream(s)
-    @assert detect_rdata(io)
+    @assert FileIO.detect_rdata(io)
     ctx = RDAContext(rdaio(io, chomp(readline(io))), kwoptions)
     @assert ctx.fmtver == 2    # format version
 #    println("Written by R version $(ctx.Rver)")
@@ -88,9 +79,5 @@ function load(s::Stream{format"RData"}, kwoptions::Vector{Any})
 end
 
 load(s::Stream{format"RData"}; kwoptions...) = load(s, kwoptions)
-
-function __init__()
-    FileIO.add_format(format"RData", detect_rdata, [".rdata", ".rda"], [:RData])
-end
 
 end # module

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -21,14 +21,6 @@ Abstract RDA format IO stream wrapper.
 """
 abstract RDAIO
 
-##############################################################################
-##
-## Utilities for reading a single data element.
-## The read<type>orNA functions are needed because the ASCII format
-## stores the NA as the string 'NA'.  Perhaps it would be easier to
-## wrap the conversion in a try/catch block.
-##
-##############################################################################
 include("io/XDRIO.jl")
 include("io/ASCIIIO.jl")
 include("io/NativeIO.jl")
@@ -42,7 +34,11 @@ include("readers.jl")
 
 ##############################################################################
 ##
-## FileIO integration
+## FileIO integration.
+## supported `kwoptions`:
+## convert::Bool (true by default) for converting R objects into Julia equivalents,
+##               otherwise load() returns R internal representation (ROBJ-derived objects)
+## TODO option for disabling names checking (e.g. column names)
 ##
 ##############################################################################
 

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -74,16 +74,16 @@ function load(s::Stream{format"RData"}, kwoptions::Vector{Any})
     # top level read -- must be a paired list of objects
     # we read it here to be able to convert to julia objects inplace
     fl = readuint32(ctx.io)
-    sxtype(fl) == LISTSXP || error( "Top level R object is not a paired list")
-    !hasattr(fl) || error( "Top level R paired list should have no attributes" )
+    sxtype(fl) == LISTSXP || error("Top level R object is not a paired list")
+    !hasattr(fl) || error("Top level R paired list should have no attributes")
 
     res = Dict{RString,Any}()
     while sxtype(fl) != NILVALUE_SXP
-        hastag(fl) || error( "Top level list element has no name")
+        hastag(fl) || error("Top level list element has no name")
         tag = readitem(ctx)
         obj_name = convert(RString, isa(tag, RSymbol) ? tag.displayname : "\0")
         obj = readitem(ctx)
-        setindex!( res, (convert2julia ? sexp2julia(obj) : obj), obj_name )
+        setindex!(res, (convert2julia ? sexp2julia(obj) : obj), obj_name)
         fl = readuint32(ctx.io)
         readattrs(ctx, fl)
     end

--- a/src/context.jl
+++ b/src/context.jl
@@ -26,8 +26,8 @@ type RDAContext{T <: RDAIO}
         kwdict = Dict{Symbol,Any}(kwoptions)
         new(io,
             fmtver,
-            VersionNumber( div(rver,65536), div(rver%65536, 256), rver%256 ),
-            VersionNumber( div(rminver,65536), div(rminver%65536, 256), rminver%256 ),
+            VersionNumber(div(rver,65536), div(rver%65536, 256), rver%256),
+            VersionNumber(div(rminver,65536), div(rminver%65536, 256), rminver%256),
             kwdict,
             RSEXPREC[])
     end

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -41,7 +41,7 @@ function DataArrays.data(ri::RIntegerVector)
 end
 
 function sexp2julia(rex::RSEXPREC)
-    warn( "Conversion of $(typeof(rex)) to Julia is not implemented" )
+    warn("Conversion of $(typeof(rex)) to Julia is not implemented")
     return nothing
 end
 
@@ -52,7 +52,7 @@ function sexp2julia(rv::RVEC)
     hasna = any(nas)
     if hasnames(rv)
         # if data has no NA, convert to simple Vector
-        return DictoVec( hasna ? DataArray(rv.data, nas) : rv.data, names(rv) )
+        return DictoVec(hasna ? DataArray(rv.data, nas) : rv.data, names(rv))
     else
         hasdims = hasdim(rv)
         if !hasdims && length(rv.data)==1
@@ -62,11 +62,12 @@ function sexp2julia(rv::RVEC)
             return rv.data[1]
         elseif !hasdims
             # vectors
-            return hasna ? DataArray( rv.data, nas ) : rv.data
+            return hasna ? DataArray(rv.data, nas) : rv.data
         else
             # matrices and so on
             dims = tuple(convert(Vector{Int64}, getattr(rv, "dim"))...)
-            return hasna ? DataArray( reshape( rv.data, dims ), reshape( nas, dims ) ) : reshape( rv.data, dims )
+            return hasna ? DataArray(reshape(rv.data, dims), reshape(nas, dims)) :
+                         reshape(rv.data, dims)
         end
     end
 end
@@ -74,9 +75,9 @@ end
 function sexp2julia(rl::RList)
     if isdataframe(rl)
         # FIXME remove Any type assertion workaround
-        DataFrame(Any[ data(col) for col in rl.data ], map(identifier, names(rl)))
+        DataFrame(Any[data(col) for col in rl.data], map(identifier, names(rl)))
     elseif hasnames(rl)
-        DictoVec(Any[sexp2julia(item) for item in rl.data ], names(rl))
+        DictoVec(Any[sexp2julia(item) for item in rl.data], names(rl))
     else
         # FIXME return DictoVec if forceDictoVec is on
         map(sexp2julia, rl.data)

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -1,4 +1,7 @@
-type ASCIIIO{T<:IO} <: RDAIO #  ASCII RData format IO stream wrapper
+"""
+    ASCII RData format IO stream wrapper.
+"""
+type ASCIIIO{T<:IO} <: RDAIO
     sub::T              # underlying IO stream
 
     ASCIIIO(io::T) = new(io)

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -1,7 +1,7 @@
 type ASCIIIO{T<:IO} <: RDAIO #  ASCII RData format IO stream wrapper
     sub::T              # underlying IO stream
 
-    ASCIIIO( io::T ) = new( io )
+    ASCIIIO(io::T) = new(io)
 end
 ASCIIIO{T <: IO}(io::T) = ASCIIIO{T}(io)
 
@@ -21,6 +21,7 @@ readintorNA(io::ASCIIIO, n::RVecLength) = Int32[readintorNA(io) for i in 1:n]
 #    str = chomp(readline(io.sub));
 #    str == R_NA_STRING ? R_NA_FLOAT64 : parse(Float64, str)
 #end
+
 function readfloatorNA(io::ASCIIIO, n::RVecLength)
     res = Vector{Float64}(n)
     res_uint = reinterpret(UInt64, res) # alias of res for setting NA

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -5,8 +5,8 @@ type ASCIIIO{T<:IO} <: RDAIO
     sub::T              # underlying IO stream
 
     ASCIIIO(io::T) = new(io)
+    @compat (::Type{ASCIIIO}){T<:IO}(io::T) = new{T}(io)
 end
-ASCIIIO{T <: IO}(io::T) = ASCIIIO{T}(io)
 
 readint32(io::ASCIIIO) = parse(Int32, readline(io.sub))
 readuint32(io::ASCIIIO) = parse(UInt32, readline(io.sub))

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -1,4 +1,9 @@
-type NativeIO{T<:IO} <: RDAIO # native binary RData format IO stream wrapper (TODO)
+"""
+    Native binary RData format IO stream wrapper.
+
+    TODO write readers
+"""
+type NativeIO{T<:IO} <: RDAIO
     sub::T               # underlying IO stream
 
     NativeIO(io::T) = new(io)

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -7,6 +7,5 @@ type NativeIO{T<:IO} <: RDAIO
     sub::T               # underlying IO stream
 
     NativeIO(io::T) = new(io)
+    @compat (::Type{NativeIO}){T<:IO}(io::T) = new{T}(io)
 end
-NativeIO{T <: IO}(io::T) = NativeIO{T}(io)
-

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -1,7 +1,7 @@
 type NativeIO{T<:IO} <: RDAIO # native binary RData format IO stream wrapper (TODO)
     sub::T               # underlying IO stream
 
-    NativeIO( io::T ) = new( io )
+    NativeIO(io::T) = new(io)
 end
 NativeIO{T <: IO}(io::T) = NativeIO{T}(io)
 

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -2,7 +2,7 @@ type XDRIO{T<:IO} <: RDAIO #  XDR(binary) RData format IO stream wrapper
     sub::T             # underlying IO stream
     buf::Vector{UInt8} # buffer for strings
 
-    XDRIO( io::T ) = new( io, Array(UInt8, 1024) )
+    XDRIO(io::T) = new(io, Array(UInt8, 1024))
 end
 XDRIO{T <: IO}(io::T) = XDRIO{T}(io)
 
@@ -16,11 +16,12 @@ readintorNA(io::XDRIO, n::RVecLength) = map!(ntoh, read(io.sub, Int32, n))
 # this method have Win32 ABI issues, see JuliaStats/RData.jl#5
 # R's NA is silently converted to NaN when the value is loaded in the register(?)
 #readfloatorNA(io::XDRIO) = readfloat64(io)
+
 readfloatorNA(io::XDRIO, n::RVecLength) = reinterpret(Float64, map!(ntoh, read(io.sub, UInt64, n)))
 
 readuint8(io::XDRIO, n::RVecLength) = readbytes(io.sub, n)
 
 function readnchars(io::XDRIO, n::Int32)  # a single character string
     readbytes!(io.sub, io.buf, n)
-    convert(RString, unsafe_string(pointer(io.buf), n) )
+    convert(RString, unsafe_string(pointer(io.buf), n))
 end

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -1,4 +1,7 @@
-type XDRIO{T<:IO} <: RDAIO #  XDR(binary) RData format IO stream wrapper
+"""
+    XDR (machine-independent binary) RData format IO stream wrapper.
+"""
+type XDRIO{T<:IO} <: RDAIO
     sub::T             # underlying IO stream
     buf::Vector{UInt8} # buffer for strings
 

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -6,8 +6,8 @@ type XDRIO{T<:IO} <: RDAIO
     buf::Vector{UInt8} # buffer for strings
 
     XDRIO(io::T) = new(io, Array(UInt8, 1024))
+    @compat (::Type{XDRIO}){T <: IO}(io::T) = new{T}(io, Array(UInt8, 1024))
 end
-XDRIO{T <: IO}(io::T) = XDRIO{T}(io)
 
 readint32(io::XDRIO) = ntoh(read(io.sub, Int32))
 readuint32(io::XDRIO) = ntoh(read(io.sub, UInt32))

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -1,3 +1,7 @@
+"""
+    Creates `RDAIO` wrapper for `io` stream depending on its format
+    specified by `formatcode`.
+"""
 function rdaio(io::IO, formatcode::AbstractString)
     if formatcode == "X" XDRIO(io)
     elseif formatcode == "A" ASCIIIO(io)

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -2,7 +2,7 @@ function rdaio(io::IO, formatcode::AbstractString)
     if formatcode == "X" XDRIO(io)
     elseif formatcode == "A" ASCIIIO(io)
     elseif formatcode == "B" NativeIO(io)
-    else error( "Unrecognized RDA format \"$formatcode\"" )
+    else error("Unrecognized RDA format \"$formatcode\"")
     end
 end
 

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -77,7 +77,7 @@ end
 
 function readenv(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == ENVSXP
-    is_locked = readint32( ctx.io )
+    is_locked = readint32(ctx.io)
     res = registerref(ctx, REnvironment()) # registering before reading the contents
     res.enclosed = readitem(ctx)
     res.frame = readitem(ctx)
@@ -149,7 +149,7 @@ end
 
 function readpromise(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == PROMSXP
-    res = RPromise( readattrs(ctx, fl) )
+    res = RPromise(readattrs(ctx, fl))
     hastag(fl) && (res.env = readitem(ctx))
     res.value = readitem(ctx)
     res.expr = readitem(ctx)

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -142,12 +142,12 @@ immutable RPairList <: ROBJ{LISTSXP}
     tags::Vector{RString}
     attr::Hash
 
-    RPairList( attr::Hash = Hash() ) = new( RSEXPREC[], RString[], attr )
+    RPairList(attr::Hash = Hash()) = new(RSEXPREC[], RString[], attr)
 end
 
-function Base.push!( pl::RPairList, item::RSEXPREC, tag::RString )
-    push!( pl.tags, tag )
-    push!( pl.items, item )
+function Base.push!(pl::RPairList, item::RSEXPREC, tag::RString)
+    push!(pl.tags, tag)
+    push!(pl.items, item)
 end
 
 type RClosure <: ROBJ{CLOSXP}
@@ -156,7 +156,7 @@ type RClosure <: ROBJ{CLOSXP}
     env
     attr::Hash
 
-    RClosure( attr::Hash = Hash() ) = new( nothing, nothing, nothing, attr )
+    RClosure(attr::Hash = Hash()) = new(nothing, nothing, nothing, attr)
 end
 
 immutable RBuiltin <: RSEXPREC{BUILTINSXP}
@@ -169,7 +169,7 @@ type RPromise <: ROBJ{PROMSXP}
     env
     attr::Hash
 
-    RPromise( attr::Hash = Hash() ) = new( nothing, nothing, nothing, attr )
+    RPromise(attr::Hash = Hash()) = new(nothing, nothing, nothing, attr)
 end
 
 type REnvironment <: ROBJ{ENVSXP}
@@ -178,7 +178,7 @@ type REnvironment <: ROBJ{ENVSXP}
     hashtab
     attr::Hash
 
-    REnvironment() = new( nothing, nothing, nothing, Hash() )
+    REnvironment() = new(nothing, nothing, nothing, Hash())
 end
 
 immutable RRaw <: ROBJ{RAWSXP}
@@ -195,7 +195,7 @@ type RExtPtr <: ROBJ{EXTPTRSXP}
     tag
     attr::Hash
 
-    RExtPtr() = new( nothing, nothing, Hash() )
+    RExtPtr() = new(nothing, nothing, Hash())
 end
 
 type RBytecode <: ROBJ{BCODESXP}
@@ -203,7 +203,8 @@ type RBytecode <: ROBJ{BCODESXP}
     tag
     car
     cdr
-    RBytecode( code = nothing, consts = nothing, attr::Hash = Hash() ) = new( attr, nothing, code, consts )
+    RBytecode(code = nothing, consts = nothing, attr::Hash = Hash()) =
+        new(attr, nothing, code, consts)
 end
 
 immutable RPackage <: RSEXPREC{PACKAGESXP}
@@ -231,8 +232,8 @@ hasattr(ro::ROBJ, attrnm) = haskey(ro.attr, attrnm)
 hasnames(ro::ROBJ) = hasattr(ro, "names")
 hasdim(ro::ROBJ) = hasattr(ro, "dim")
 hasdimnames(ro::ROBJ) = hasattr(ro, "dimnames")
-getattr(ro::ROBJ, attrnm) = getindex( ro.attr, attrnm ).data
-getattr(ro::ROBJ, attrnm, default) = hasattr( ro, attrnm ) ? getindex( ro.attr, attrnm ).data : default
+getattr(ro::ROBJ, attrnm) = getindex(ro.attr, attrnm).data
+getattr(ro::ROBJ, attrnm, default) = hasattr(ro, attrnm) ? getindex(ro.attr, attrnm).data : default
 
 Base.names(ro::ROBJ) = getattr(ro, "names")
 


### PR DESCRIPTION
Don't `add_format()` for RData, because it's automatically done by FileIO since v0.1.2 (JuliaIO/FileIO.jl#75).

Also a few whitespace fixes.