### PR TITLE
Make DataArrays using explicit

### DIFF
--- a/src/RData.jl
+++ b/src/RData.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module RData
 
-using Compat, DataFrames, GZip, FileIO
+using Compat, DataFrames, GZip, FileIO, DataArrays  
 import DataArrays: data
 import DataFrames: identifier
 import Compat: UTF8String, unsafe_string


### PR DESCRIPTION
Came up while reviewing https://github.com/JuliaStats/DataFrames.jl/pull/1008 because DataFrames no longer will do `using DataArrays`
