### PR TITLE
2-argument map! calls => 3-argument calls

### DIFF
--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -14,13 +14,19 @@ readuint32(io::XDRIO) = ntoh(read(io.sub, UInt32))
 readfloat64(io::XDRIO) = ntoh(read(io.sub, Float64))
 
 readintorNA(io::XDRIO) = readint32(io)
-readintorNA(io::XDRIO, n::RVecLength) = map!(ntoh, read(io.sub, Int32, n))
+function readintorNA(io::XDRIO, n::RVecLength) 
+    v = read(io.sub, Int32, n)
+    map!(ntoh, v, v)
+end
 
 # this method have Win32 ABI issues, see JuliaStats/RData.jl#5
 # R's NA is silently converted to NaN when the value is loaded in the register(?)
 #readfloatorNA(io::XDRIO) = readfloat64(io)
 
-readfloatorNA(io::XDRIO, n::RVecLength) = reinterpret(Float64, map!(ntoh, read(io.sub, UInt64, n)))
+function readfloatorNA(io::XDRIO, n::RVecLength)
+    v = read(io.sub, UInt64, n)
+    reinterpret(Float64, map!(ntoh, v, v))
+end
 
 readuint8(io::XDRIO, n::RVecLength) = readbytes(io.sub, n)
 


### PR DESCRIPTION
Julia v0.6 deprecates the use of 2-argument `map!` calls in favor of the 3 argument form.