### PR TITLE
Suppress warnings on julia v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,4 @@ DataFrames 0.7
 DataArrays 0.3
 FileIO 0.1.2
 GZip 0.2
-Compat 0.8
+Compat 0.17

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 DataFrames 0.7
 DataArrays 0.3
 FileIO 0.1.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -5,7 +5,7 @@ module RData
 using Compat, DataFrames, GZip, FileIO
 import DataArrays: data
 import DataFrames: identifier
-import Compat: UTF8String, unsafe_string
+import Compat: unsafe_string
 import FileIO: load
 
 export

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -19,7 +19,7 @@ include("sxtypes.jl")
 """
 Abstract RDA format IO stream wrapper.
 """
-abstract RDAIO
+@compat abstract type RDAIO end
 
 include("io/XDRIO.jl")
 include("io/ASCIIIO.jl")

--- a/src/config.jl
+++ b/src/config.jl
@@ -30,14 +30,10 @@ const R_NA_STRING = "NA"
 
 const LONG_VECTOR_SUPPORT = (Sys.WORD_SIZE > 32) # disable long vectors support on 32-bit machines
 
-if LONG_VECTOR_SUPPORT
-    typealias RVecLength Int64
-else
-    typealias RVecLength Int
-end
+const RVecLength = LONG_VECTOR_SUPPORT ? Int64 : Int
 
-typealias RString UTF8String     # default String container for R string
-typealias Hash Dict{RString, Any}
+const RString = UTF8String     # default String container for R string
+const Hash = Dict{RString, Any}
 
 const emptyhash = Hash()
 const emptyhashkey = RString("\0")

--- a/src/config.jl
+++ b/src/config.jl
@@ -32,7 +32,7 @@ const LONG_VECTOR_SUPPORT = (Sys.WORD_SIZE > 32) # disable long vectors support 
 
 const RVecLength = LONG_VECTOR_SUPPORT ? Int64 : Int
 
-const RString = UTF8String     # default String container for R string
+const RString = String     # default String container for R string
 const Hash = Dict{RString, Any}
 
 const emptyhash = Hash()

--- a/src/context.jl
+++ b/src/context.jl
@@ -1,16 +1,14 @@
 """
     RDA (R data archive) reading context.
 
-    * Stores flags that define how R objects are read and converted
-      into Julia objects.
-    * Maintains the list of R objects that could be referenced later in
-      the RDA stream.
+* Stores flags that define how R objects are read and converted into Julia objects.
+* Maintains the list of R objects that could be referenced later in the RDA stream.
 """
-type RDAContext{T <: RDAIO}
+type RDAContext{T<:RDAIO}
     io::T                      # RDA input stream
 
     # RDA format properties
-    fmtver::UInt32             # format version
+    fmtver::Int32             # format version
     Rver::VersionNumber        # R version used to write the file
     Rmin::VersionNumber        # minimal R version to read the file
 
@@ -18,22 +16,19 @@ type RDAContext{T <: RDAIO}
 
     # intermediate data
     ref_tab::Vector{RSEXPREC}  # SEXP array for references
-
-    function RDAContext(io::T, kwoptions::Vector{Any})
-        fmtver = readint32(io)
-        rver = readint32(io)
-        rminver = readint32(io)
-        kwdict = Dict{Symbol,Any}(kwoptions)
-        new(io,
-            fmtver,
-            VersionNumber(div(rver,65536), div(rver%65536, 256), rver%256),
-            VersionNumber(div(rminver,65536), div(rminver%65536, 256), rminver%256),
-            kwdict,
-            RSEXPREC[])
-    end
 end
-
-RDAContext{T <: RDAIO}(io::T, kwoptions::Vector{Any}) = RDAContext{T}(io, kwoptions)
+function RDAContext{T<:RDAIO}(io::T, kwoptions::Vector{Any}=Any[])
+  fmtver = readint32(io)
+  rver = readint32(io)
+  rminver = readint32(io)
+  kwdict = Dict{Symbol,Any}(kwoptions)
+  RDAContext(io,
+      fmtver,
+      VersionNumber(div(rver,65536), div(rver%65536, 256), rver%256),
+      VersionNumber(div(rminver,65536), div(rminver%65536, 256), rminver%256),
+      kwdict,
+      RSEXPREC[])
+end
 
 """
     Registers R object, so that it could be referenced later

--- a/src/context.jl
+++ b/src/context.jl
@@ -8,7 +8,7 @@ type RDAContext{T<:RDAIO}
     io::T                      # RDA input stream
 
     # RDA format properties
-    fmtver::Int32             # format version
+    fmtver::UInt32             # format version
     Rver::VersionNumber        # R version used to write the file
     Rmin::VersionNumber        # minimal R version to read the file
 
@@ -17,17 +17,13 @@ type RDAContext{T<:RDAIO}
     # intermediate data
     ref_tab::Vector{RSEXPREC}  # SEXP array for references
 end
+int2ver(v::Integer) = VersionNumber(v >> 16, (v >> 8) & 0xff, v & 0xff)
 function RDAContext{T<:RDAIO}(io::T, kwoptions::Vector{Any}=Any[])
-  fmtver = readint32(io)
-  rver = readint32(io)
-  rminver = readint32(io)
-  kwdict = Dict{Symbol,Any}(kwoptions)
-  RDAContext(io,
-      fmtver,
-      VersionNumber(div(rver,65536), div(rver%65536, 256), rver%256),
-      VersionNumber(div(rminver,65536), div(rminver%65536, 256), rminver%256),
-      kwdict,
-      RSEXPREC[])
+    fmtver = readuint32(io)
+    rver = int2ver(readint32(io))
+    rminver = int2ver(readint32(io))
+    kwdict = Dict{Symbol,Any}(kwoptions)
+    RDAContext(io, fmtver, rver, rminver, kwdict, RSEXPREC[])
 end
 
 """

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -4,7 +4,7 @@
 type ASCIIIO{T<:IO} <: RDAIO
     sub::T              # underlying IO stream
 
-    @compat (::Type{ASCIIIO}){T<:IO}(io::T) = new{T}(io)
+    (::Type{ASCIIIO}){T<:IO}(io::T) = new{T}(io)
 end
 
 readint32(io::ASCIIIO) = parse(Int32, readline(io.sub))

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -4,7 +4,6 @@
 type ASCIIIO{T<:IO} <: RDAIO
     sub::T              # underlying IO stream
 
-    ASCIIIO(io::T) = new(io)
     @compat (::Type{ASCIIIO}){T<:IO}(io::T) = new{T}(io)
 end
 

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -5,5 +5,5 @@
 """
 type NativeIO{T<:IO} <: RDAIO
     sub::T               # underlying IO stream
-    @compat (::Type{NativeIO}){T<:IO}(io::T) = new{T}(io)
+    (::Type{NativeIO}){T<:IO}(io::T) = new{T}(io)
 end

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -5,7 +5,5 @@
 """
 type NativeIO{T<:IO} <: RDAIO
     sub::T               # underlying IO stream
-
-    NativeIO(io::T) = new(io)
     @compat (::Type{NativeIO}){T<:IO}(io::T) = new{T}(io)
 end

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -9,22 +9,16 @@ end
 
 readint32(io::XDRIO) = ntoh(read(io.sub, Int32))
 readuint32(io::XDRIO) = ntoh(read(io.sub, UInt32))
-readfloat64(io::XDRIO) = ntoh(read(io.sub, Float64))
+readfloat64(io::XDRIO) = reinterpret(Float64, ntoh(read(io.sub, Int64)))
 
 readintorNA(io::XDRIO) = readint32(io)
-function readintorNA(io::XDRIO, n::RVecLength)
-    v = read(io.sub, Int32, n)
-    map!(ntoh, v, v)
-end
+readintorNA(io::XDRIO, n::RVecLength) = [readint32(io) for _ in 1:n]
 
 # this method have Win32 ABI issues, see JuliaStats/RData.jl#5
 # R's NA is silently converted to NaN when the value is loaded in the register(?)
 #readfloatorNA(io::XDRIO) = readfloat64(io)
 
-function readfloatorNA(io::XDRIO, n::RVecLength)
-    v = read(io.sub, UInt64, n)
-    reinterpret(Float64, map!(ntoh, v, v))
-end
+readfloatorNA(io::XDRIO, n::RVecLength) = [readfloat64(io) for _ in 1:n]
 
 readuint8(io::XDRIO, n::RVecLength) = readbytes(io.sub, n)
 

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -4,9 +4,7 @@
 type XDRIO{T<:IO} <: RDAIO
     sub::T             # underlying IO stream
     buf::Vector{UInt8} # buffer for strings
-
-    XDRIO(io::T) = new(io, Array(UInt8, 1024))
-    @compat (::Type{XDRIO}){T <: IO}(io::T) = new{T}(io, Array(UInt8, 1024))
+    @compat (::Type{XDRIO}){T <: IO}(io::T) = new{T}(io, Array{UInt8}(1024))
 end
 
 readint32(io::XDRIO) = ntoh(read(io.sub, Int32))
@@ -14,7 +12,7 @@ readuint32(io::XDRIO) = ntoh(read(io.sub, UInt32))
 readfloat64(io::XDRIO) = ntoh(read(io.sub, Float64))
 
 readintorNA(io::XDRIO) = readint32(io)
-function readintorNA(io::XDRIO, n::RVecLength) 
+function readintorNA(io::XDRIO, n::RVecLength)
     v = read(io.sub, Int32, n)
     map!(ntoh, v, v)
 end

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -184,7 +184,7 @@ immutable BytecodeContext
     ctx::RDAContext         # parent RDA context
     ref_tab::Vector{Any}    # table of bytecode references
 
-    BytecodeContext(ctx::RDAContext, nrefs::Int32) = new(ctx, Array(Any, Int(nrefs)))
+    BytecodeContext(ctx::RDAContext, nrefs::Int32) = new(ctx, Array{Any}(Int(nrefs)))
 end
 
 const BYTECODELANG_Types = Set([BCREPREF, BCREPDEF, LANGSXP, LISTSXP, ATTRLANGSXP, ATTRLISTSXP])

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -184,7 +184,7 @@ immutable BytecodeContext
     ctx::RDAContext         # parent RDA context
     ref_tab::Vector{Any}    # table of bytecode references
 
-    BytecodeContext(ctx::RDAContext, nrefs::Int32) = new(ctx, Array{Any}(Int(nrefs)))
+    BytecodeContext(ctx::RDAContext, nrefs::Int32) = new(ctx, Vector{Any}(Int(nrefs)))
 end
 
 const BYTECODELANG_Types = Set([BCREPREF, BCREPDEF, LANGSXP, LISTSXP, ATTRLANGSXP, ATTRLISTSXP])

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -231,7 +231,7 @@ function readbytecodeconsts(bctx::BytecodeContext)
             readitem(bctx.ctx)
         end
     end
-    return RList(v)
+    return RList(v, Hash())
 end
 
 function readbytecodecontents(bctx::BytecodeContext)

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -231,7 +231,7 @@ function readbytecodeconsts(bctx::BytecodeContext)
             readitem(bctx.ctx)
         end
     end
-    return RList(v, Hash())
+    return RList(v)
 end
 
 function readbytecodecontents(bctx::BytecodeContext)
@@ -254,7 +254,7 @@ end
     Definition of R type.
 """
 immutable SXTypeInfo
-    name::UTF8String     # R type name
+    name::String         # R type name
     reader::Function     # function to deserialize R type from RDA stream
 end
 

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -112,8 +112,7 @@ type RVector{T, S} <: RVEC{T, S}
     data::Vector{T}
     attr::Hash                   # collection of R object attributes
 
-    RVector(v::Vector{T} = T[], attr::Hash = Hash()) = new(v, attr)
-
+    (::Type{RVector{T,S}}){T,S}(v::Vector{T}=T[], attr::Hash=Hash()) = new{T,S}(v, attr)
 end
 
 const RLogicalVector = RVector{Int32, LGLSXP}

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -111,8 +111,10 @@ end
 type RVector{T, S} <: RVEC{T, S}
     data::Vector{T}
     attr::Hash                   # collection of R object attributes
+
+    @compat RVector{T,S}(v::Vector{T} = T[], attr::Hash = Hash()) where {T,S} = new(v, attr)
+
 end
-RVector{T}(v::Vector{T} = T[]) = RVector(v, Hash())
 
 const RLogicalVector = RVector{Int32, LGLSXP}
 const RIntegerVector = RVector{Int32, INTSXP}

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -68,7 +68,7 @@ const ATTRLISTSXP =       0xEF
 ##
 ##############################################################################
 
-typealias RDATag UInt32
+const RDATag = UInt32
 
 isobj(fl::RDATag) = (fl & 0x00000100) != 0
 hasattr(fl::RDATag) = (fl & 0x00000200) != 0
@@ -85,7 +85,7 @@ sxtype(fl::RDATag) = fl % UInt8
     Base class for RData internal representation of all R types.
     `SEXPREC` stands for S (R predecessor) expression record.
 """
-abstract RSEXPREC{S}
+@compat abstract type RSEXPREC{S} end
 
 """
     R symbol.
@@ -98,12 +98,12 @@ end
 """
     Base class for all R types (objects) that can have attributes.
 """
-abstract ROBJ{S} <: RSEXPREC{S}
+@compat abstract type ROBJ{S} <: RSEXPREC{S} end
 
 """
    Base class for all R vector-like objects.
 """
-abstract RVEC{T, S} <: ROBJ{S}
+@compat abstract type RVEC{T, S} <: ROBJ{S} end
 
 """
     R vector object.
@@ -111,14 +111,13 @@ abstract RVEC{T, S} <: ROBJ{S}
 type RVector{T, S} <: RVEC{T, S}
     data::Vector{T}
     attr::Hash                   # collection of R object attributes
-
-    RVector(v::Vector{T} = T[], attr::Hash = Hash()) = new(v, attr)
 end
+RVector{T}(v::Vector{T} = T[]) = RVector(v, Hash())
 
-typealias RLogicalVector RVector{Int32, LGLSXP}
-typealias RIntegerVector RVector{Int32, INTSXP}
-typealias RNumericVector RVector{Float64, REALSXP}
-typealias RComplexVector RVector{Complex128, CPLXSXP}
+const RLogicalVector = RVector{Int32, LGLSXP}
+const RIntegerVector = RVector{Int32, INTSXP}
+const RNumericVector = RVector{Float64, REALSXP}
+const RComplexVector = RVector{Complex128, CPLXSXP}
 
 """
     R vector object with explicit NA values.
@@ -129,12 +128,12 @@ immutable RNullableVector{T, S} <: RVEC{T, S}
     attr::Hash                   # collection of R object attributes
 end
 
-typealias RStringVector RNullableVector{RString,STRSXP}
-typealias RList RVector{RSEXPREC,VECSXP}  # "list" in R == Julia cell array
+const RStringVector = RNullableVector{RString,STRSXP}
+const RList = RVector{RSEXPREC,VECSXP}  # "list" in R == Julia cell array
 
 """
     Representation of R's paired list-like structures (`LISTSXP`, `LANGSXP`).
-    Unlike R that represents it as singly-linked list,
+    Unlike R which represents these as singly-linked list,
     `RPairList` uses vector representation.
 """
 immutable RPairList <: ROBJ{LISTSXP}

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -112,7 +112,7 @@ type RVector{T, S} <: RVEC{T, S}
     data::Vector{T}
     attr::Hash                   # collection of R object attributes
 
-    @compat RVector{T,S}(v::Vector{T} = T[], attr::Hash = Hash()) where {T,S} = new(v, attr)
+    RVector(v::Vector{T} = T[], attr::Hash = Hash()) = new(v, attr)
 
 end
 


### PR DESCRIPTION
Building on the work by @wookay but allowing for this version to continue to be used with v0.5

I also tightened the code in a couple of places.