### PR TITLE
Switch from GZip to CodecZlib

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,9 @@ Updated to Julia v0.6 (older versions not supported).
 ##### Changes
 * R logical vectors are converted to `DataVector{Bool}` (instead of `DataVector{Int32}`) [#32]
 * dropped compatibility with Julia versions prior v0.6 [#32]
+* use CodecZlib for gzipped RData files (instead of outdated GZip) [#31]
 
+[#31]: https://github.com/JuliaStats/RData.jl/issues/31
 [#32]: https://github.com/JuliaStats/RData.jl/issues/32
 
 ## RData v0.0.4 Release Notes

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6
 DataFrames 0.9
 DataArrays 0.4
 FileIO 0.1.2
-GZip 0.2
+CodecZlib 0.4


### PR DESCRIPTION
[CodecZlib.jl](https://github.com/bicycle1885/CodecZlib.jl) will eventually completely replace GZip.jl.
It also offers more complete `IO` interface implementation, e.g. `GzipCompressorStream` could be used by `CSV.jl` to read gzipped tables.
So by switching to CodecZlib we avoid having two different packages providing gzip support in different contexts.
See bicycle1885/CodecZlib.jl#7 for more details.

Gzip.jl checks whether the input stream is actually compressed, and silently switches to no-op wrapper if it's not.
CodecZlib throws an exception for uncompressed streams, so we have to check for it before.
