### PR TITLE
Update to Julia v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## RData v0.1.0 Release Notes
+
+Updated to Julia v0.6 (older versions not supported).
+
+##### Changes
+* dropped compatibility with Julia versions prior v0.6 [#32]
+
+[#32]: https://github.com/JuliaStats/RData.jl/issues/32
+
 ## RData v0.0.4 Release Notes
 
 Now the recommended way to load `.RData`/`.rda` files is by `FileIO.load()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 Updated to Julia v0.6 (older versions not supported).
 
 ##### Changes
+* R logical vectors are converted to `DataVector{Bool}` (instead of `DataVector{Int32}`) [#32]
 * dropped compatibility with Julia versions prior v0.6 [#32]
 
 [#32]: https://github.com/JuliaStats/RData.jl/issues/32

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RData
 
-[![Julia 0.4 Status](http://pkg.julialang.org/badges/RData_0.4.svg)](http://pkg.julialang.org/?pkg=RData&ver=0.4)
-[![Julia 0.5 Status](http://pkg.julialang.org/badges/RData_0.5.svg)](http://pkg.julialang.org/?pkg=RData&ver=0.5)
+[![Julia 0.6 Status](http://pkg.julialang.org/badges/RData_0.6.svg)](http://pkg.julialang.org/?pkg=RData&ver=0.6)
 
 [![Coverage Status](https://coveralls.io/repos/github/JuliaStats/RData.jl/badge.svg)](https://coveralls.io/github/JuliaStats/RData.jl)
 [![Build Status](https://travis-ci.org/JuliaStats/RData.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/RData.jl)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
-julia 0.5
-DataFrames 0.7
-DataArrays 0.3
+julia 0.6
+DataFrames 0.9
+DataArrays 0.4
 FileIO 0.1.2
 GZip 0.2
-Compat 0.17

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/DictoVec.jl
+++ b/src/DictoVec.jl
@@ -11,9 +11,9 @@ function name2index(names::Vector{RString})
 end
 
 """
-    Container that mimics R vector behaviour.
-    Elements could be accessed either by indices as a normal vector,
-    or (optionally) by string keys as a dictionary.
+Container that mimics R vector behaviour.
+Elements could be accessed either by indices as a normal vector,
+or (optionally) by string keys as a dictionary.
 """
 immutable DictoVec{T}
     data::T

--- a/src/DictoVec.jl
+++ b/src/DictoVec.jl
@@ -15,12 +15,12 @@ Container that mimics R vector behaviour.
 Elements could be accessed either by indices as a normal vector,
 or (optionally) by string keys as a dictionary.
 """
-immutable DictoVec{T}
+struct DictoVec{T}
     data::T
     name2index::Dict{RString, Int}
     index2name::Dict{Int, RString}
 
-    @compat function (::Type{DictoVec}){T}(data::T, names::Vector{RString} = Vector{RString}())
+    function (::Type{DictoVec})(data::T, names::Vector{RString} = Vector{RString}()) where T
         n2i, i2n = name2index(names)
         new{T}(data, n2i, i2n)
     end

--- a/src/RData.jl
+++ b/src/RData.jl
@@ -2,10 +2,8 @@ __precompile__()
 
 module RData
 
-using Compat, DataFrames, GZip, FileIO
-import DataArrays: data
+using DataFrames, DataArrays, GZip, FileIO
 import DataFrames: identifier
-import Compat: unsafe_string
 import FileIO: load
 
 export
@@ -19,7 +17,7 @@ include("sxtypes.jl")
 """
 Abstract RDA format IO stream wrapper.
 """
-@compat abstract type RDAIO end
+abstract type RDAIO end
 
 include("io/XDRIO.jl")
 include("io/ASCIIIO.jl")

--- a/src/config.jl
+++ b/src/config.jl
@@ -5,9 +5,9 @@
 ##############################################################################
 
 """
-    Non-standard addition to NaN bit pattern to discriminate NA from NaN.
-    0x000007a2 == UInt32(1954)
-    (I assume 1954 is the year of Ross's birth or something like that.)
+Non-standard addition to NaN bit pattern to discriminate NA from NaN.
+0x000007a2 == UInt32(1954)
+(I assume 1954 is the year of Ross's birth or something like that.)
 """
 const R_NA_FLOAT64_LOW = 0x000007a2
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -32,7 +32,7 @@ end
 Register R object, so that it could be referenced later
 (by its index in the reference table).
 """
-function registerref(ctx::RDAContext, obj::RSEXPREC)
+function registerref!(ctx::RDAContext, obj::RSEXPREC)
     push!(ctx.ref_tab, obj)
     obj
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -4,7 +4,7 @@ RDA (R data archive) reading context.
 * Stores flags that define how R objects are read and converted into Julia objects.
 * Maintains the list of R objects that could be referenced later in the RDA stream.
 """
-type RDAContext{T<:RDAIO}
+struct RDAContext{T<:RDAIO}
     io::T                      # RDA input stream
 
     # RDA format properties
@@ -20,7 +20,7 @@ end
 
 int2ver(v::Integer) = VersionNumber(v >> 16, (v >> 8) & 0xff, v & 0xff)
 
-function RDAContext{T<:RDAIO}(io::T, kwoptions::Vector{Any}=Any[])
+function RDAContext(io::RDAIO, kwoptions::Vector{Any}=Any[])
     fmtver = readuint32(io)
     rver = int2ver(readint32(io))
     rminver = int2ver(readint32(io))

--- a/src/context.jl
+++ b/src/context.jl
@@ -1,5 +1,5 @@
 """
-    RDA (R data archive) reading context.
+RDA (R data archive) reading context.
 
 * Stores flags that define how R objects are read and converted into Julia objects.
 * Maintains the list of R objects that could be referenced later in the RDA stream.
@@ -17,7 +17,9 @@ type RDAContext{T<:RDAIO}
     # intermediate data
     ref_tab::Vector{RSEXPREC}  # SEXP array for references
 end
+
 int2ver(v::Integer) = VersionNumber(v >> 16, (v >> 8) & 0xff, v & 0xff)
+
 function RDAContext{T<:RDAIO}(io::T, kwoptions::Vector{Any}=Any[])
     fmtver = readuint32(io)
     rver = int2ver(readint32(io))
@@ -27,8 +29,8 @@ function RDAContext{T<:RDAIO}(io::T, kwoptions::Vector{Any}=Any[])
 end
 
 """
-    Registers R object, so that it could be referenced later
-    (by its index in the reference table).
+Register R object, so that it could be referenced later
+(by its index in the reference table).
 """
 function registerref(ctx::RDAContext, obj::RSEXPREC)
     push!(ctx.ref_tab, obj)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -40,6 +40,10 @@ function DataArrays.data(ri::RIntegerVector)
     return PooledDataArray(DataArrays.RefArray(refs), pool)
 end
 
+# convert R logical vector (uses Int32 to store values) into DataVector{Bool}
+DataArrays.data(rl::RLogicalVector) =
+    return DataArray(Bool[x != 0 for x in rl.data], namask(rl))
+
 function sexp2julia(rex::RSEXPREC)
     warn("Conversion of $(typeof(rex)) to Julia is not implemented")
     return nothing

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -1,5 +1,5 @@
 """
-    ASCII RData format IO stream wrapper.
+ASCII RData format IO stream wrapper.
 """
 type ASCIIIO{T<:IO} <: RDAIO
     sub::T              # underlying IO stream

--- a/src/io/ASCIIIO.jl
+++ b/src/io/ASCIIIO.jl
@@ -1,10 +1,10 @@
 """
 ASCII RData format IO stream wrapper.
 """
-type ASCIIIO{T<:IO} <: RDAIO
+struct ASCIIIO{T<:IO} <: RDAIO
     sub::T              # underlying IO stream
 
-    (::Type{ASCIIIO}){T<:IO}(io::T) = new{T}(io)
+    (::Type{ASCIIIO})(io::T) where {T<:IO} = new{T}(io)
 end
 
 readint32(io::ASCIIIO) = parse(Int32, readline(io.sub))

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -3,7 +3,7 @@ Native binary RData format IO stream wrapper.
 
 TODO write readers
 """
-type NativeIO{T<:IO} <: RDAIO
+struct NativeIO{T<:IO} <: RDAIO
     sub::T               # underlying IO stream
-    (::Type{NativeIO}){T<:IO}(io::T) = new{T}(io)
+    (::Type{NativeIO})(io::T) where {T<:IO} = new{T}(io)
 end

--- a/src/io/NativeIO.jl
+++ b/src/io/NativeIO.jl
@@ -1,7 +1,7 @@
 """
-    Native binary RData format IO stream wrapper.
+Native binary RData format IO stream wrapper.
 
-    TODO write readers
+TODO write readers
 """
 type NativeIO{T<:IO} <: RDAIO
     sub::T               # underlying IO stream

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -4,7 +4,7 @@
 type XDRIO{T<:IO} <: RDAIO
     sub::T             # underlying IO stream
     buf::Vector{UInt8} # buffer for strings
-    @compat (::Type{XDRIO}){T <: IO}(io::T) = new{T}(io, Vector{UInt8}(1024))
+    (::Type{XDRIO}){T <: IO}(io::T) = new{T}(io, Vector{UInt8}(1024))
 end
 
 readint32(io::XDRIO) = ntoh(read(io.sub, Int32))

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -1,10 +1,10 @@
 """
 XDR (machine-independent binary) RData format IO stream wrapper.
 """
-type XDRIO{T<:IO} <: RDAIO
+struct XDRIO{T<:IO} <: RDAIO
     sub::T             # underlying IO stream
     buf::Vector{UInt8} # buffer for strings
-    (::Type{XDRIO}){T <: IO}(io::T) = new{T}(io, Vector{UInt8}(1024))
+    (::Type{XDRIO})(io::T) where {T <: IO} = new{T}(io, Vector{UInt8}(1024))
 end
 
 readint32(io::XDRIO) = ntoh(read(io.sub, Int32))

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -25,7 +25,7 @@ function readfloatorNA(io::XDRIO, n::RVecLength)
     reinterpret(Float64, map!(ntoh, v, v))
 end
 
-readuint8(io::XDRIO, n::RVecLength) = readbytes(io.sub, n)
+readuint8(io::XDRIO, n::RVecLength) = read(io.sub, UInt8, n)
 
 function readnchars(io::XDRIO, n::Int32)  # a single character string
     readbytes!(io.sub, io.buf, n)

--- a/src/io/XDRIO.jl
+++ b/src/io/XDRIO.jl
@@ -1,5 +1,5 @@
 """
-    XDR (machine-independent binary) RData format IO stream wrapper.
+XDR (machine-independent binary) RData format IO stream wrapper.
 """
 type XDRIO{T<:IO} <: RDAIO
     sub::T             # underlying IO stream

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -41,9 +41,9 @@ else
     end
 end
 
-immutable CHARSXProps # RDA CHARSXP properties
-  levs::UInt32       # level flags (encoding etc) TODO process
-  nchar::Int32       # string length, -1 for NA strings
+struct CHARSXProps # RDA CHARSXP properties
+    levs::UInt32       # level flags (encoding etc) TODO process
+    nchar::Int32       # string length, -1 for NA strings
 end
 
 function readcharsxprops(io::RDAIO) # read character string encoding and length

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -6,7 +6,7 @@ function rdaio(io::IO, formatcode::AbstractString)
     if formatcode == "X" XDRIO(io)
     elseif formatcode == "A" ASCIIIO(io)
     elseif formatcode == "B" NativeIO(io)
-    else error("Unrecognized RDA format \"$formatcode\"")
+    else throw(ArgumentError("Unrecognized RDA format \"$formatcode\""))
     end
 end
 

--- a/src/io/utils.jl
+++ b/src/io/utils.jl
@@ -1,6 +1,6 @@
 """
-    Creates `RDAIO` wrapper for `io` stream depending on its format
-    specified by `formatcode`.
+Creates `RDAIO` wrapper for `io` stream depending on its format
+specified by `formatcode`.
 """
 function rdaio(io::IO, formatcode::AbstractString)
     if formatcode == "X" XDRIO(io)

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -178,7 +178,7 @@ function readextptr(ctx::RDAContext, fl::RDATag)
 end
 
 """
-    Context for reading R bytecode.
+Context for reading R bytecode.
 """
 immutable BytecodeContext
     ctx::RDAContext         # parent RDA context
@@ -251,7 +251,7 @@ function readunsupported(ctx::RDAContext, fl::RDATag)
 end
 
 """
-    Definition of R type.
+Definition of R type.
 """
 immutable SXTypeInfo
     name::String         # R type name
@@ -259,7 +259,7 @@ immutable SXTypeInfo
 end
 
 """
-    Maps R type id (`SXType`) to its `SXTypeInfo`.
+Maps R type id (`SXType`) to its `SXTypeInfo`.
 """
 const SXTypes = Dict{SXType, SXTypeInfo}(
     NILSXP     => SXTypeInfo("NULL",readdummy),

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -65,7 +65,7 @@ end
 
 function readsymbol(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == SYMSXP
-    registerref(ctx, RSymbol(readcharacter(ctx.io)))
+    registerref!(ctx, RSymbol(readcharacter(ctx.io)))
 end
 
 function readS4(ctx::RDAContext, fl::RDATag)
@@ -78,7 +78,7 @@ end
 function readenv(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == ENVSXP
     is_locked = readint32(ctx.io)
-    res = registerref(ctx, REnvironment()) # registering before reading the contents
+    res = registerref!(ctx, REnvironment()) # registering before reading the contents
     res.enclosed = readitem(ctx)
     res.frame = readitem(ctx)
     res.hashtab = readitem(ctx)
@@ -98,12 +98,12 @@ end
 
 function readnamespace(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == NAMESPACESXP
-    registerref(ctx, RNamespace(readname(ctx)))
+    registerref!(ctx, RNamespace(readname(ctx)))
 end
 
 function readpackage(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == PACKAGESXP
-    registerref(ctx, RPackage(readname(ctx)))
+    registerref!(ctx, RPackage(readname(ctx)))
 end
 
 # reads single-linked lists R objects
@@ -170,7 +170,7 @@ end
 
 function readextptr(ctx::RDAContext, fl::RDATag)
     @assert sxtype(fl) == EXTPTRSXP
-    res = registerref(ctx, RExtPtr()) # registering before reading the contents
+    res = registerref!(ctx, RExtPtr()) # registering before reading the contents
     res.protected = readitem(ctx)
     res.tag = readitem(ctx)
     res.attr = readattrs(ctx, fl)

--- a/src/readers.jl
+++ b/src/readers.jl
@@ -180,7 +180,7 @@ end
 """
 Context for reading R bytecode.
 """
-immutable BytecodeContext
+struct BytecodeContext
     ctx::RDAContext         # parent RDA context
     ref_tab::Vector{Any}    # table of bytecode references
 
@@ -253,7 +253,7 @@ end
 """
 Definition of R type.
 """
-immutable SXTypeInfo
+struct SXTypeInfo
     name::String         # R type name
     reader::Function     # function to deserialize R type from RDA stream
 end

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -82,31 +82,31 @@ sxtype(fl::RDATag) = fl % UInt8
 ##############################################################################
 
 """
-    Base class for RData internal representation of all R types.
-    `SEXPREC` stands for S (R predecessor) expression record.
+Base class for RData internal representation of all R types.
+`SEXPREC` stands for S (R predecessor) expression record.
 """
 @compat abstract type RSEXPREC{S} end
 
 """
-    R symbol.
-    Not quite the same as a Julia symbol.
+R symbol.
+Not quite the same as a Julia symbol.
 """
 immutable RSymbol <: RSEXPREC{SYMSXP}
     displayname::RString
 end
 
 """
-    Base class for all R types (objects) that can have attributes.
+Base class for all R types (objects) that can have attributes.
 """
 @compat abstract type ROBJ{S} <: RSEXPREC{S} end
 
 """
-   Base class for all R vector-like objects.
+Base class for all R vector-like objects.
 """
 @compat abstract type RVEC{T, S} <: ROBJ{S} end
 
 """
-    R vector object.
+R vector object.
 """
 type RVector{T, S} <: RVEC{T, S}
     data::Vector{T}
@@ -121,7 +121,7 @@ const RNumericVector = RVector{Float64, REALSXP}
 const RComplexVector = RVector{Complex128, CPLXSXP}
 
 """
-    R vector object with explicit NA values.
+R vector object with explicit NA values.
 """
 immutable RNullableVector{T, S} <: RVEC{T, S}
     data::Vector{T}
@@ -133,9 +133,9 @@ const RStringVector = RNullableVector{RString,STRSXP}
 const RList = RVector{RSEXPREC,VECSXP}  # "list" in R == Julia cell array
 
 """
-    Representation of R's paired list-like structures (`LISTSXP`, `LANGSXP`).
-    Unlike R which represents these as singly-linked list,
-    `RPairList` uses vector representation.
+Representation of R's paired list-like structures (`LISTSXP`, `LANGSXP`).
+Unlike R which represents these as singly-linked list,
+`RPairList` uses vector representation.
 """
 immutable RPairList <: ROBJ{LISTSXP}
     items::Vector{RSEXPREC}

--- a/src/sxtypes.jl
+++ b/src/sxtypes.jl
@@ -85,34 +85,35 @@ sxtype(fl::RDATag) = fl % UInt8
 Base class for RData internal representation of all R types.
 `SEXPREC` stands for S (R predecessor) expression record.
 """
-@compat abstract type RSEXPREC{S} end
+abstract type RSEXPREC{S} end
 
 """
 R symbol.
 Not quite the same as a Julia symbol.
 """
-immutable RSymbol <: RSEXPREC{SYMSXP}
+struct RSymbol <: RSEXPREC{SYMSXP}
     displayname::RString
 end
 
 """
 Base class for all R types (objects) that can have attributes.
 """
-@compat abstract type ROBJ{S} <: RSEXPREC{S} end
+abstract type ROBJ{S} <: RSEXPREC{S} end
 
 """
 Base class for all R vector-like objects.
 """
-@compat abstract type RVEC{T, S} <: ROBJ{S} end
+abstract type RVEC{T, S} <: ROBJ{S} end
 
 """
 R vector object.
 """
-type RVector{T, S} <: RVEC{T, S}
+struct RVector{T, S} <: RVEC{T, S}
     data::Vector{T}
     attr::Hash                   # collection of R object attributes
 
-    (::Type{RVector{T,S}}){T,S}(v::Vector{T}=T[], attr::Hash=Hash()) = new{T,S}(v, attr)
+    (::Type{RVector{T,S}})(v::Vector{T}=T[], attr::Hash=Hash()) where {T,S} =
+        new{T,S}(v, attr)
 end
 
 const RLogicalVector = RVector{Int32, LGLSXP}
@@ -123,7 +124,7 @@ const RComplexVector = RVector{Complex128, CPLXSXP}
 """
 R vector object with explicit NA values.
 """
-immutable RNullableVector{T, S} <: RVEC{T, S}
+struct RNullableVector{T, S} <: RVEC{T, S}
     data::Vector{T}
     na::BitVector                # mask of NA elements
     attr::Hash                   # collection of R object attributes
@@ -137,7 +138,7 @@ Representation of R's paired list-like structures (`LISTSXP`, `LANGSXP`).
 Unlike R which represents these as singly-linked list,
 `RPairList` uses vector representation.
 """
-immutable RPairList <: ROBJ{LISTSXP}
+struct RPairList <: ROBJ{LISTSXP}
     items::Vector{RSEXPREC}
     tags::Vector{RString}
     attr::Hash
@@ -150,7 +151,7 @@ function Base.push!(pl::RPairList, item::RSEXPREC, tag::RString)
     push!(pl.items, item)
 end
 
-type RClosure <: ROBJ{CLOSXP}
+mutable struct RClosure <: ROBJ{CLOSXP}
     formals
     body
     env
@@ -159,11 +160,11 @@ type RClosure <: ROBJ{CLOSXP}
     RClosure(attr::Hash = Hash()) = new(nothing, nothing, nothing, attr)
 end
 
-immutable RBuiltin <: RSEXPREC{BUILTINSXP}
+struct RBuiltin <: RSEXPREC{BUILTINSXP}
     internal_function::RString
 end
 
-type RPromise <: ROBJ{PROMSXP}
+mutable struct RPromise <: ROBJ{PROMSXP}
     value
     expr
     env
@@ -172,7 +173,7 @@ type RPromise <: ROBJ{PROMSXP}
     RPromise(attr::Hash = Hash()) = new(nothing, nothing, nothing, attr)
 end
 
-type REnvironment <: ROBJ{ENVSXP}
+mutable struct REnvironment <: ROBJ{ENVSXP}
     enclosed
     frame
     hashtab
@@ -181,16 +182,16 @@ type REnvironment <: ROBJ{ENVSXP}
     REnvironment() = new(nothing, nothing, nothing, Hash())
 end
 
-immutable RRaw <: ROBJ{RAWSXP}
+struct RRaw <: ROBJ{RAWSXP}
     data::Vector{UInt8}
     attr::Hash
 end
 
-immutable RS4Obj <: ROBJ{S4SXP}
+struct RS4Obj <: ROBJ{S4SXP}
     attr::Hash
 end
 
-type RExtPtr <: ROBJ{EXTPTRSXP}
+mutable struct RExtPtr <: ROBJ{EXTPTRSXP}
     protected
     tag
     attr::Hash
@@ -198,7 +199,7 @@ type RExtPtr <: ROBJ{EXTPTRSXP}
     RExtPtr() = new(nothing, nothing, Hash())
 end
 
-type RBytecode <: ROBJ{BCODESXP}
+mutable struct RBytecode <: ROBJ{BCODESXP}
     attr::Hash
     tag
     car
@@ -207,16 +208,16 @@ type RBytecode <: ROBJ{BCODESXP}
         new(attr, nothing, code, consts)
 end
 
-immutable RPackage <: RSEXPREC{PACKAGESXP}
+struct RPackage <: RSEXPREC{PACKAGESXP}
     name::Vector{RString}
 end
 
-immutable RNamespace <: RSEXPREC{NAMESPACESXP}
+struct RNamespace <: RSEXPREC{NAMESPACESXP}
     name::Vector{RString}
 end
 
 # R objects without body (empty environments, missing args etc)
-immutable RDummy{S} <: RSEXPREC{S}
+struct RDummy{S} <: RSEXPREC{S}
 end
 
 ##############################################################################

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -5,50 +5,70 @@ module TestRDA
     using Compat
 
     # check for Float64 NA
-    @test !RData.isna_float64(reinterpret(UInt64, 1.0))
-    @test !RData.isna_float64(reinterpret(UInt64, NaN))
-    @test !RData.isna_float64(reinterpret(UInt64, Inf))
-    @test !RData.isna_float64(reinterpret(UInt64, -Inf))
-    @test RData.isna_float64(reinterpret(UInt64, RData.R_NA_FLOAT64))
-    # check that alternative NA is also recognized (#10)
-    @test RData.isna_float64(reinterpret(UInt64, RData.R_NA_FLOAT64 | ((Base.significand_mask(Float64) + 1) >> 1)))
+    @testset "Detect R floating-point NAs" begin
+        @test !RData.isna_float64(reinterpret(UInt64, 1.0))
+        @test !RData.isna_float64(reinterpret(UInt64, NaN))
+        @test !RData.isna_float64(reinterpret(UInt64, Inf))
+        @test !RData.isna_float64(reinterpret(UInt64, -Inf))
+        @test RData.isna_float64(reinterpret(UInt64, RData.R_NA_FLOAT64))
+        # check that alternative NA is also recognized (#10)
+        @test RData.isna_float64(reinterpret(UInt64, RData.R_NA_FLOAT64 | ((Base.significand_mask(Float64) + 1) >> 1)))
+    end
 
     testdir = dirname(@__FILE__)
+    @testset "Reading minimal RData" begin
+        df = DataFrame(num = [1.1, 2.2])
+        @test isequal(sexp2julia(load("$testdir/data/minimal.rda",convert=false)["df"]), df)
+        @test isequal(load("$testdir/data/minimal.rda",convert=true)["df"], df)
+        @test isequal(load("$testdir/data/minimal_ascii.rda")["df"], df)
+    end
 
-    df = DataFrame(num = [1.1, 2.2])
-    @test isequal(sexp2julia(load("$testdir/data/minimal.rda",convert=false)["df"]), df)
-    @test isequal(load("$testdir/data/minimal.rda",convert=true)["df"], df)
-    @test isequal(load("$testdir/data/minimal_ascii.rda")["df"], df)
+    @testset "Conversion to Julia types" begin
+        df = DataFrame(num = [1.1, 2.2],
+                       int = Int32[1, 2],
+                       logi = [true, false],
+                       chr = ["ab", "c"],
+                       factor = pool(["ab", "c"]),
+                       cplx = Complex128[1.1+0.5im, 1.0im])
+        rdf = sexp2julia(load("$testdir/data/types.rda",convert=false)["df"])
+        @test eltypes(rdf) == eltypes(df)
+        @test isequal(rdf, df)
+        rdf_ascii = sexp2julia(load("$testdir/data/types_ascii.rda",convert=false)["df"])
+        @test eltypes(rdf_ascii) == eltypes(df)
+        @test isequal(rdf_ascii, df)
+    end
 
-    df[:int] = Int32[1, 2]
-    df[:logi] = [true, false]
-    df[:chr] = ["ab", "c"]
-    df[:factor] = pool(df[:chr])
-    df[:cplx] = Complex128[1.1+0.5im, 1.0im]
-    @test isequal(sexp2julia(load("$testdir/data/types.rda",convert=false)["df"]), df)
-    @test isequal(sexp2julia(load("$testdir/data/types_ascii.rda",convert=false)["df"]), df)
+    @testset "NAs conversion" begin
+        df = DataFrame(num = [1.1, 2.2],
+                       int = Int32[1, 2],
+                       logi = [true, false],
+                       chr = ["ab", "c"],
+                       factor = pool(["ab", "c"]),
+                       cplx = Complex128[1.1+0.5im, 1.0im])
 
-    df[2, :] = NA
-    append!(df, df[2, :])
-    df[3, :num] = NaN
-    df[:, :cplx] = @data [NA, @compat(Complex128(1,NaN)), NaN]
-    @test isequal(sexp2julia(load("$testdir/data/NAs.rda",convert=false)["df"]), df)
-    # ASCII format saves NaN as NA
-    df[3, :num] = NA
-    df[:, :cplx] = @data [NA, NA, NA]
-    @test isequal(sexp2julia(load("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
+        df[2, :] = NA
+        append!(df, df[2, :])
+        df[3, :num] = NaN
+        df[:, :cplx] = @data [NA, Complex128(1,NaN), NaN]
+        @test isequal(sexp2julia(load("$testdir/data/NAs.rda",convert=false)["df"]), df)
+        # ASCII format saves NaN as NA
+        df[3, :num] = NA
+        df[:, :cplx] = @data [NA, NA, NA]
+        @test isequal(sexp2julia(load("$testdir/data/NAs_ascii.rda",convert=false)["df"]), df)
+    end
 
-    rda_names = names(sexp2julia(load("$testdir/data/names.rda",convert=false)["df"]))
-    expected_names = [:_end, :x!, :x1, :_B_C_, :x, :x_1]
-    @test rda_names == expected_names
-    rda_names = names(sexp2julia(load("$testdir/data/names_ascii.rda",convert=false)["df"]))
-    @test rda_names == [:_end, :x!, :x1, :_B_C_, :x, :x_1]
+    @testset "Column names conversion" begin
+        rda_names = names(sexp2julia(load("$testdir/data/names.rda",convert=false)["df"]))
+        expected_names = [:_end, :x!, :x1, :_B_C_, :x, :x_1]
+        @test rda_names == expected_names
+        rda_names = names(sexp2julia(load("$testdir/data/names_ascii.rda",convert=false)["df"]))
+        @test rda_names == [:_end, :x!, :x1, :_B_C_, :x, :x_1]
+    end
 
-    rda_envs = load("$testdir/data/envs.rda",convert=false)
-
-    rda_pairlists = load("$testdir/data/pairlists.rda",convert=false)
-
-    rda_closures = load("$testdir/data/closures.rda",convert=false)
-
-    rda_cmpfuns = load("$testdir/data/cmpfun.rda",convert=false)
+    @testset "Reading RDA with complex types (environments, closures etc)" begin
+        rda_envs = load("$testdir/data/envs.rda",convert=false)
+        rda_pairlists = load("$testdir/data/pairlists.rda",convert=false)
+        rda_closures = load("$testdir/data/closures.rda",convert=false)
+        rda_cmpfuns = load("$testdir/data/cmpfun.rda",convert=false)
+    end
 end

--- a/test/RDA.jl
+++ b/test/RDA.jl
@@ -2,7 +2,6 @@ module TestRDA
     using Base.Test
     using DataFrames
     using RData
-    using Compat
 
     # check for Float64 NA
     @testset "Detect R floating-point NAs" begin


### PR DESCRIPTION
Cherry-picked from #28: update to Julia v0.6 (support for prior versions dropped), excluding the migration to DataFrames v0.11/CategoricalArrays/Nulls + minor tweaks.
I tried to make the commits atomic, so no squashing is required.

It would allow merging #31.